### PR TITLE
Update resnetv1b.py

### DIFF
--- a/core/models/base_models/resnetv1b.py
+++ b/core/models/base_models/resnetv1b.py
@@ -92,7 +92,7 @@ class BottleneckV1b(nn.Module):
 class ResNetV1b(nn.Module):
 
     def __init__(self, block, layers, num_classes=1000, dilated=True, deep_stem=False,
-                 zero_init_residual=False, norm_layer=nn.BatchNorm2d):
+                 zero_init_residual=False, local_rank=0,norm_layer=nn.BatchNorm2d):
         self.inplanes = 128 if deep_stem else 64
         super(ResNetV1b, self).__init__()
         if deep_stem:


### PR DESCRIPTION
# Solve a problem
when you execute  "python eval.py --model psp --dataset citys"
There will be an error
```
python eval.py --model psp --dataset citys
Found 500 images in the folder /home/data/citys/leftImg8bit/val
Traceback (most recent call last):
  File "eval.py", line 113, in <module>
    evaluator = Evaluator(args)
  File "eval.py", line 51, in __init__
    norm_layer=BatchNorm2d).to(self.device)
  File "/home/ypl/assp/awesome-semantic-segmentation-pytorch/core/models/model_zoo.py", line 122, in get_segmentation_model
    return models[model](**kwargs)
  File "/home/ypl/assp/awesome-semantic-segmentation-pytorch/core/models/pspnet.py", line 132, in get_psp
    model = PSPNet(datasets[dataset].NUM_CLASS, backbone=backbone, pretrained_base=pretrained_base, **kwargs)
  File "/home/ypl/assp/awesome-semantic-segmentation-pytorch/core/models/pspnet.py", line 35, in __init__
    super(PSPNet, self).__init__(nclass, aux, backbone, pretrained_base=pretrained_base, **kwargs)
  File "/home/ypl/assp/awesome-semantic-segmentation-pytorch/core/models/segbase.py", line 26, in __init__
    self.pretrained = resnet50_v1s(pretrained=pretrained_base, dilated=dilated, **kwargs)
  File "/home/ypl/assp/awesome-semantic-segmentation-pytorch/core/models/base_models/resnetv1b.py", line 236, in resnet50_v1s
    model = ResNetV1b(BottleneckV1b, [3, 4, 6, 3], deep_stem=True, **kwargs)
TypeError: __init__() got an unexpected keyword argument 'local_rank'
```